### PR TITLE
fix/dto-stub-fix

### DIFF
--- a/src/Console/stubs/dto.stub
+++ b/src/Console/stubs/dto.stub
@@ -31,7 +31,7 @@ class {{ class }} extends ValidatedDTO
      *
      * @return array
      */
-    abstract protected function casts(): array
+    protected function casts(): array
     {
         return [];
     }

--- a/tests/Feature/MakeDTOCommandTest.php
+++ b/tests/Feature/MakeDTOCommandTest.php
@@ -31,6 +31,16 @@ class UserDTO extends ValidatedDTO
     }
 
     /**
+     * Defines the type casting for the properties of the DTO.
+     *
+     * @return array
+     */
+    protected function casts(): array
+    {
+        return [];
+    }
+
+    /**
      * Defines the custom messages for validator errors.
      *
      * @return array


### PR DESCRIPTION
This PR intends to make a simple fix to the DTO stub file. 

The stub file has the `abstract` keyword on the `casts` method, which is clearly not the intention of the `casts` method. Hence, this PR removes that keyword and also updates the test case to check for the casts method as well.

So when you run the command to generate a validated DTO, you get `protected function casts(): array` and not `abstract protected function casts(): array`.