### PR TITLE
Add feature to cast Eloquent Models properties to DTOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,6 +761,53 @@ class CustomDTO extends ValidatedDTO
 }
 ```
 
+## Casting Eloquent Model properties to DTOs
+
+You can easily cast any **Eloquent Model** properties to your **DTOs**:
+
+```php
+class MyModel extends Model
+{
+    protected $fillable = ['name', 'metadata'];
+
+    protected $casts = [
+        'metadata' => AttributesDTO::class,
+    ];
+}
+```
+
+The **DTO** class:
+
+```php
+class AttributesDTO extends ValidatedDTO
+{
+    public int $age;
+
+    public string $doc;
+
+    protected function rules(): array
+    {
+        return [
+            'age' => ['required', 'integer'],
+            'doc' => ['required', 'string'],
+        ];
+    }
+
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'age' => new IntegerCast(),
+            'doc' => new StringCast(),
+        ];
+    }
+}
+```
+
 ## Credits
 
 - [Wendell Adriel](https://github.com/WendellAdriel)

--- a/composer.json
+++ b/composer.json
@@ -38,10 +38,10 @@
     "illuminate/http": "^7.0|^8.0|^9.0|^10.0",
     "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
     "illuminate/validation": "^7.0|^8.0|^9.0|^10.0",
-    "laravel/pint": "^1.4.1",
+    "laravel/pint": "^1.7.0",
     "orchestra/testbench": "^6.0|^7.20|^8.0",
-    "pestphp/pest": "^1.22.3",
-    "pestphp/pest-plugin-faker": "^1.0"
+    "pestphp/pest": "^2.0",
+    "pestphp/pest-plugin-faker": "^2.0"
   },
   "scripts": {
     "lint": "pint",

--- a/src/Casting/ArrayCast.php
+++ b/src/Casting/ArrayCast.php
@@ -4,11 +4,6 @@ namespace WendellAdriel\ValidatedDTO\Casting;
 
 class ArrayCast implements Castable
 {
-    /**
-     * @param  string  $property
-     * @param  mixed  $value
-     * @return array
-     */
     public function cast(string $property, mixed $value): array
     {
         if (is_string($value)) {

--- a/src/Casting/BooleanCast.php
+++ b/src/Casting/BooleanCast.php
@@ -4,11 +4,6 @@ namespace WendellAdriel\ValidatedDTO\Casting;
 
 class BooleanCast implements Castable
 {
-    /**
-     * @param  string  $property
-     * @param  mixed  $value
-     * @return bool
-     */
     public function cast(string $property, mixed $value): bool
     {
         if (is_numeric($value)) {

--- a/src/Casting/CarbonCast.php
+++ b/src/Casting/CarbonCast.php
@@ -8,10 +8,6 @@ use WendellAdriel\ValidatedDTO\Exceptions\CastException;
 
 class CarbonCast implements Castable
 {
-    /**
-     * @param  string|null  $timezone
-     * @param  string|null  $format
-     */
     public function __construct(
         private ?string $timezone = null,
         private ?string $format = null
@@ -19,10 +15,6 @@ class CarbonCast implements Castable
     }
 
     /**
-     * @param  string  $property
-     * @param  mixed  $value
-     * @return Carbon
-     *
      * @throws CastException
      */
     public function cast(string $property, mixed $value): Carbon

--- a/src/Casting/CarbonImmutableCast.php
+++ b/src/Casting/CarbonImmutableCast.php
@@ -8,10 +8,6 @@ use WendellAdriel\ValidatedDTO\Exceptions\CastException;
 
 class CarbonImmutableCast implements Castable
 {
-    /**
-     * @param  string|null  $timezone
-     * @param  string|null  $format
-     */
     public function __construct(
         private ?string $timezone = null,
         private ?string $format = null
@@ -19,10 +15,6 @@ class CarbonImmutableCast implements Castable
     }
 
     /**
-     * @param  string  $property
-     * @param  mixed  $value
-     * @return CarbonImmutable
-     *
      * @throws CastException
      */
     public function cast(string $property, mixed $value): CarbonImmutable

--- a/src/Casting/Castable.php
+++ b/src/Casting/Castable.php
@@ -6,10 +6,6 @@ interface Castable
 {
     /**
      * Casts the given value.
-     *
-     * @param  string  $property
-     * @param  mixed  $value
-     * @return mixed
      */
     public function cast(string $property, mixed $value): mixed;
 }

--- a/src/Casting/CollectionCast.php
+++ b/src/Casting/CollectionCast.php
@@ -6,18 +6,10 @@ use Illuminate\Support\Collection;
 
 class CollectionCast implements Castable
 {
-    /**
-     * @param  Castable|null  $type
-     */
     public function __construct(private ?Castable $type = null)
     {
     }
 
-    /**
-     * @param  string  $property
-     * @param  mixed  $value
-     * @return Collection
-     */
     public function cast(string $property, mixed $value): Collection
     {
         $arrayCast = new ArrayCast();

--- a/src/Casting/DTOCast.php
+++ b/src/Casting/DTOCast.php
@@ -10,18 +10,11 @@ use WendellAdriel\ValidatedDTO\ValidatedDTO;
 
 class DTOCast implements Castable
 {
-    /**
-     * @param  string  $dtoClass
-     */
     public function __construct(private string $dtoClass)
     {
     }
 
     /**
-     * @param  string  $property
-     * @param  mixed  $value
-     * @return ValidatedDTO
-     *
      * @throws CastException|CastTargetException|ValidationException
      */
     public function cast(string $property, mixed $value): ValidatedDTO

--- a/src/Casting/FloatCast.php
+++ b/src/Casting/FloatCast.php
@@ -7,10 +7,6 @@ use WendellAdriel\ValidatedDTO\Exceptions\CastException;
 class FloatCast implements Castable
 {
     /**
-     * @param  string  $property
-     * @param  mixed  $value
-     * @return float
-     *
      * @throws CastException
      */
     public function cast(string $property, mixed $value): float

--- a/src/Casting/IntegerCast.php
+++ b/src/Casting/IntegerCast.php
@@ -7,10 +7,6 @@ use WendellAdriel\ValidatedDTO\Exceptions\CastException;
 class IntegerCast implements Castable
 {
     /**
-     * @param  string  $property
-     * @param  mixed  $value
-     * @return int
-     *
      * @throws CastException
      */
     public function cast(string $property, mixed $value): int

--- a/src/Casting/ModelCast.php
+++ b/src/Casting/ModelCast.php
@@ -9,18 +9,11 @@ use WendellAdriel\ValidatedDTO\Exceptions\CastTargetException;
 
 class ModelCast implements Castable
 {
-    /**
-     * @param  string  $modelClass
-     */
     public function __construct(private string $modelClass)
     {
     }
 
     /**
-     * @param  string  $property
-     * @param  mixed  $value
-     * @return Model
-     *
      * @throws CastException|CastTargetException
      */
     public function cast(string $property, mixed $value): Model

--- a/src/Casting/ObjectCast.php
+++ b/src/Casting/ObjectCast.php
@@ -7,10 +7,6 @@ use WendellAdriel\ValidatedDTO\Exceptions\CastException;
 class ObjectCast implements Castable
 {
     /**
-     * @param  string  $property
-     * @param  mixed  $value
-     * @return object
-     *
      * @throws CastException
      */
     public function cast(string $property, mixed $value): object

--- a/src/Casting/StringCast.php
+++ b/src/Casting/StringCast.php
@@ -8,10 +8,6 @@ use WendellAdriel\ValidatedDTO\Exceptions\CastException;
 class StringCast implements Castable
 {
     /**
-     * @param  string  $property
-     * @param  mixed  $value
-     * @return string
-     *
      * @throws CastException
      */
     public function cast(string $property, mixed $value): string

--- a/src/Console/Commands/MakeDTOCommand.php
+++ b/src/Console/Commands/MakeDTOCommand.php
@@ -67,8 +67,6 @@ class MakeDTOCommand extends GeneratorCommand
 
     /**
      * Get the stub file for the generator.
-     *
-     * @return string
      */
     protected function getStub(): string
     {
@@ -77,8 +75,6 @@ class MakeDTOCommand extends GeneratorCommand
 
     /**
      * Get the console command options.
-     *
-     * @return array
      */
     protected function getOptions(): array
     {

--- a/src/Exceptions/CastException.php
+++ b/src/Exceptions/CastException.php
@@ -7,9 +7,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CastException extends Exception
 {
-    /**
-     * @param  string  $property
-     */
     public function __construct(string $property)
     {
         parent::__construct("Unable to cast property: {$property} - invalid value", Response::HTTP_UNPROCESSABLE_ENTITY);

--- a/src/Exceptions/CastTargetException.php
+++ b/src/Exceptions/CastTargetException.php
@@ -7,9 +7,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CastTargetException extends Exception
 {
-    /**
-     * @param  string  $property
-     */
     public function __construct(string $property)
     {
         parent::__construct("The property: {$property} has an invalid cast configuration", Response::HTTP_UNPROCESSABLE_ENTITY);

--- a/src/Exceptions/MissingCastTypeException.php
+++ b/src/Exceptions/MissingCastTypeException.php
@@ -7,9 +7,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class MissingCastTypeException extends Exception
 {
-    /**
-     * @param  string  $property
-     */
     public function __construct(string $property)
     {
         parent::__construct("Missing cast type configuration for property: {$property}", Response::HTTP_UNPROCESSABLE_ENTITY);

--- a/src/ValidatedDTO.php
+++ b/src/ValidatedDTO.php
@@ -23,8 +23,6 @@ abstract class ValidatedDTO
     private \Illuminate\Contracts\Validation\Validator|\Illuminate\Validation\Validator $validator;
 
     /**
-     * @param  array  $data
-     *
      * @throws ValidationException|MissingCastTypeException|CastTargetException
      */
     public function __construct(array $data)
@@ -38,20 +36,11 @@ abstract class ValidatedDTO
             : $this->failedValidation();
     }
 
-    /**
-     * @param  string  $name
-     * @param  mixed  $value
-     * @return void
-     */
     public function __set(string $name, mixed $value): void
     {
         $this->{$name} = $value;
     }
 
-    /**
-     * @param  string  $name
-     * @return mixed
-     */
     public function __get(string $name): mixed
     {
         return $this->{$name} ?? null;
@@ -59,29 +48,22 @@ abstract class ValidatedDTO
 
     /**
      * Defines the validation rules for the DTO.
-     *
-     * @return array
      */
     abstract protected function rules(): array;
 
     /**
      * Defines the default values for the properties of the DTO.
-     *
-     * @return array
      */
     abstract protected function defaults(): array;
 
     /**
      * Defines the type casting for the properties of the DTO.
-     *
-     * @return array
      */
     abstract protected function casts(): array;
 
     /**
      * Creates a DTO instance from a valid JSON string.
      *
-     * @param  string  $json
      * @return $this
      *
      * @throws InvalidJsonException|ValidationException|MissingCastTypeException|CastTargetException
@@ -99,7 +81,6 @@ abstract class ValidatedDTO
     /**
      * Creates a DTO instance from a Request.
      *
-     * @param  Request  $request
      * @return $this
      *
      * @throws ValidationException|MissingCastTypeException|CastTargetException
@@ -112,7 +93,6 @@ abstract class ValidatedDTO
     /**
      * Creates a DTO instance from the given model.
      *
-     * @param  Model  $model
      * @return $this
      *
      * @throws ValidationException|MissingCastTypeException|CastTargetException
@@ -125,7 +105,6 @@ abstract class ValidatedDTO
     /**
      * Creates a DTO instance from the given command arguments.
      *
-     * @param  Command  $command
      * @return $this
      *
      * @throws ValidationException|MissingCastTypeException|CastTargetException
@@ -138,7 +117,6 @@ abstract class ValidatedDTO
     /**
      * Creates a DTO instance from the given command options.
      *
-     * @param  Command  $command
      * @return $this
      *
      * @throws ValidationException|MissingCastTypeException|CastTargetException
@@ -151,7 +129,6 @@ abstract class ValidatedDTO
     /**
      * Creates a DTO instance from the given command arguments and options.
      *
-     * @param  Command  $command
      * @return $this
      *
      * @throws ValidationException|MissingCastTypeException|CastTargetException
@@ -163,8 +140,6 @@ abstract class ValidatedDTO
 
     /**
      * Returns the DTO validated data in array format.
-     *
-     * @return array
      */
     public function toArray(): array
     {
@@ -173,9 +148,6 @@ abstract class ValidatedDTO
 
     /**
      * Returns the DTO validated data in a JSON string format.
-     *
-     * @param  bool  $pretty
-     * @return string
      */
     public function toJson(bool $pretty = false): string
     {
@@ -186,9 +158,6 @@ abstract class ValidatedDTO
 
     /**
      * Creates a new model with the DTO validated data.
-     *
-     * @param  string  $model
-     * @return Model
      */
     public function toModel(string $model): Model
     {
@@ -197,8 +166,6 @@ abstract class ValidatedDTO
 
     /**
      * Defines the custom messages for validator errors.
-     *
-     * @return array
      */
     public function messages(): array
     {
@@ -207,8 +174,6 @@ abstract class ValidatedDTO
 
     /**
      * Defines the custom attributes for validator errors.
-     *
-     * @return array
      */
     public function attributes(): array
     {
@@ -218,7 +183,6 @@ abstract class ValidatedDTO
     /**
      * Handles a passed validation attempt.
      *
-     * @return void
      *
      * @throws MissingCastTypeException|CastTargetException
      */
@@ -262,7 +226,6 @@ abstract class ValidatedDTO
     /**
      * Handles a failed validation attempt.
      *
-     * @return void
      *
      * @throws ValidationException
      */
@@ -273,8 +236,6 @@ abstract class ValidatedDTO
 
     /**
      * Inits the configuration for the DTOs.
-     *
-     * @return void
      */
     private function initConfig(): void
     {
@@ -286,8 +247,6 @@ abstract class ValidatedDTO
 
     /**
      * Checks if the data is valid for the DTO.
-     *
-     * @return bool
      */
     private function isValidData(): bool
     {
@@ -304,7 +263,6 @@ abstract class ValidatedDTO
     /**
      * Builds the validated data from the given data and the rules.
      *
-     * @return array
      *
      * @throws MissingCastTypeException|CastTargetException
      */

--- a/tests/Datasets/AttributesDTO.php
+++ b/tests/Datasets/AttributesDTO.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WendellAdriel\ValidatedDTO\Tests\Datasets;
+
+use WendellAdriel\ValidatedDTO\Casting\IntegerCast;
+use WendellAdriel\ValidatedDTO\Casting\StringCast;
+use WendellAdriel\ValidatedDTO\ValidatedDTO;
+
+class AttributesDTO extends ValidatedDTO
+{
+    public int $age;
+
+    public string $doc;
+
+    protected function rules(): array
+    {
+        return [
+            'age' => ['required', 'integer'],
+            'doc' => ['required', 'string'],
+        ];
+    }
+
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'age' => new IntegerCast(),
+            'doc' => new StringCast(),
+        ];
+    }
+}

--- a/tests/Datasets/ModelCastInstance.php
+++ b/tests/Datasets/ModelCastInstance.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace WendellAdriel\ValidatedDTO\Tests\Datasets;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ModelCastInstance extends Model
+{
+    protected $fillable = ['name', 'metadata'];
+
+    protected $casts = [
+        'metadata' => AttributesDTO::class,
+    ];
+}

--- a/tests/Feature/MakeDTOCommandTest.php
+++ b/tests/Feature/MakeDTOCommandTest.php
@@ -15,8 +15,6 @@ it('generates a new ValidatedDTO class via command', function () {
 
 /**
  * Content of the expected UserDTO class
- *
- * @return string
  */
 function UserDTO(): string
 {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -45,8 +45,6 @@ expect()->extend('toBeFileWithContent', function (string $fileContent) {
 
 /**
  * Returns the string "test_property"
- *
- * @return string
  */
 function test_property(): string
 {

--- a/tests/Unit/AttributeCastTest.php
+++ b/tests/Unit/AttributeCastTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use WendellAdriel\ValidatedDTO\Tests\Datasets\AttributesDTO;
+use WendellAdriel\ValidatedDTO\Tests\Datasets\ModelCastInstance;
+
+it('properly casts a Model property to a DTO class', function () {
+    $model = new ModelCastInstance([
+        'name' => fake()->name,
+        'metadata' => '{"age": 10, "doc": "foo"}',
+    ]);
+
+    expect($model->metadata)
+        ->toBeInstanceOf(AttributesDTO::class);
+});

--- a/tests/Unit/ValidatedDTOTest.php
+++ b/tests/Unit/ValidatedDTOTest.php
@@ -5,13 +5,13 @@ use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
-use function Pest\Faker\faker;
+use function Pest\Faker\fake;
 use WendellAdriel\ValidatedDTO\Exceptions\InvalidJsonException;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\ValidatedDTOInstance;
 use WendellAdriel\ValidatedDTO\ValidatedDTO;
 
 beforeEach(function () {
-    $this->subject_name = faker()->name;
+    $this->subject_name = fake()->name;
 });
 
 it('instantiates a ValidatedDTO validating its data', function () {


### PR DESCRIPTION
As discussed in #11, this PR enables the support to use **DTO** classes to cast **Eloquent Models** properties.