### PR TITLE
Add support for null values 

### DIFF
--- a/tests/Datasets/NullableDTO.php
+++ b/tests/Datasets/NullableDTO.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WendellAdriel\ValidatedDTO\Tests\Datasets;
+
+use WendellAdriel\ValidatedDTO\Casting\IntegerCast;
+use WendellAdriel\ValidatedDTO\Casting\StringCast;
+use WendellAdriel\ValidatedDTO\ValidatedDTO;
+
+class NullableDTO extends ValidatedDTO
+{
+    public string $name;
+
+    public ?int $age;
+
+    public ?string $address;
+
+    protected function rules(): array
+    {
+        return [
+            'name' => ['required', 'string'],
+            'age' => ['optional', 'integer'],
+            'address' => ['nullable', 'string'],
+        ];
+    }
+
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'name' => new StringCast(),
+            'age' => new IntegerCast(),
+            'address' => new StringCast(),
+        ];
+    }
+}

--- a/tests/Unit/ValidatedDTOTest.php
+++ b/tests/Unit/ValidatedDTOTest.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use function Pest\Faker\faker;
 use WendellAdriel\ValidatedDTO\Exceptions\InvalidJsonException;
+use WendellAdriel\ValidatedDTO\Tests\Datasets\NullableDTO;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\ValidatedDTOInstance;
 use WendellAdriel\ValidatedDTO\ValidatedDTO;
 
@@ -27,6 +28,21 @@ it('instantiates a ValidatedDTO validating its data', function () {
 it('throws exception when trying to instantiate a ValidatedDTO with invalid data')
     ->expect(fn () => new ValidatedDTOInstance([]))
     ->throws(ValidationException::class);
+
+it('instantiates a ValidatedDTO with nullable and optional properties', function () {
+    $dto = new NullableDTO([
+        'name' => $this->subject_name,
+        'address' => null,
+    ]);
+
+    expect($dto)->toBeInstanceOf(NullableDTO::class)
+        ->and($dto->name)
+        ->toBeString()
+        ->and($dto->age)
+        ->toBeNull()
+        ->and($dto->address)
+        ->toBeNull();
+});
 
 it('returns null when trying to access a property that does not exist', function () {
     $validatedDTO = new ValidatedDTOInstance(['name' => $this->subject_name]);


### PR DESCRIPTION
As reported in #13, defining a property as nullable or optional and defining a cast throws an error if the value is nullable. This PR fixes this by adding support for null values when a property is defined as optional or nullable in the rules.