### PR TITLE
Fix dependencies on composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,14 +30,14 @@
     }
   ],
   "require": {
-    "php": "^8.0"
+    "php": "^8.0",
+    "illuminate/console": "^9.0|^10.0",
+    "illuminate/database": "^9.0|^10.0",
+    "illuminate/http": "^9.0|^10.0",
+    "illuminate/support": "^9.0|^10.0",
+    "illuminate/validation": "^9.0|^10.0"
   },
   "require-dev": {
-    "illuminate/console": "^7.0|^8.0|^9.0|^10.0",
-    "illuminate/database": "^7.0|^8.0|^9.0|^10.0",
-    "illuminate/http": "^7.0|^8.0|^9.0|^10.0",
-    "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
-    "illuminate/validation": "^7.0|^8.0|^9.0|^10.0",
     "laravel/pint": "~1.5.0",
     "orchestra/testbench": "^6.0|^7.20|^8.0",
     "pestphp/pest": "v1.22.6",


### PR DESCRIPTION
As reported in #19, some dependencies that are on require-dev should be on require in the composer.json file. This PR is fixing this.