### PR TITLE
Adding pipelines to process the data

### DIFF
--- a/src/Casting/DTOCast.php
+++ b/src/Casting/DTOCast.php
@@ -10,8 +10,10 @@ use WendellAdriel\ValidatedDTO\ValidatedDTO;
 
 class DTOCast implements Castable
 {
-    public function __construct(private string $dtoClass)
-    {
+    public function __construct(
+        private string $dtoClass,
+        private array $config = []
+    ) {
     }
 
     /**
@@ -28,7 +30,7 @@ class DTOCast implements Castable
         }
 
         try {
-            $dto = new $this->dtoClass($value);
+            $dto = new $this->dtoClass($value, $this->config);
         } catch (ValidationException $exception) {
             throw $exception;
         } catch (Throwable) {

--- a/src/Pipes/ConvertKeysToCamelCasePipe.php
+++ b/src/Pipes/ConvertKeysToCamelCasePipe.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WendellAdriel\ValidatedDTO\Pipes;
+
+use Closure;
+use Illuminate\Support\Str;
+
+class ConvertKeysToCamelCasePipe
+{
+    public function handle(array $array, Closure $next)
+    {
+        foreach ($array as $key => $value) {
+            if ($key == ($camelCaseKey = Str::camel($key))) {
+                continue;
+            }
+
+            $array[$camelCaseKey] = $value;
+            unset($array[$key]);
+        }
+
+        return $next($array);
+    }
+}

--- a/src/Pipes/ConvertKeysToPascalCasePipe.php
+++ b/src/Pipes/ConvertKeysToPascalCasePipe.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WendellAdriel\ValidatedDTO\Pipes;
+
+use Closure;
+use Illuminate\Support\Str;
+
+class ConvertKeysToPascalCasePipe
+{
+    public function handle(array $array, Closure $next)
+    {
+        foreach ($array as $key => $value) {
+            if ($key == ($camelCaseKey = ucfirst(Str::camel($key)))) {
+                continue;
+            }
+
+            $array[$camelCaseKey] = $value;
+            unset($array[$key]);
+        }
+
+        return $next($array);
+    }
+}

--- a/src/Pipes/ConvertKeysToSnakeCasePipe.php
+++ b/src/Pipes/ConvertKeysToSnakeCasePipe.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WendellAdriel\ValidatedDTO\Pipes;
+
+use Closure;
+use Illuminate\Support\Str;
+
+class ConvertKeysToSnakeCasePipe
+{
+    public function handle(array $array, Closure $next)
+    {
+        foreach ($array as $key => $value) {
+            if ($key == ($camelCaseKey = Str::snake($key))) {
+                continue;
+            }
+
+            $array[$camelCaseKey] = $value;
+            unset($array[$key]);
+        }
+
+        return $next($array);
+    }
+}

--- a/src/Pipes/ExtractNestedDTOsToArraysPipe.php
+++ b/src/Pipes/ExtractNestedDTOsToArraysPipe.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace WendellAdriel\ValidatedDTO\Pipes;
+
+use Closure;
+use WendellAdriel\ValidatedDTO\ValidatedDTO;
+
+class ExtractNestedDTOsToArraysPipe
+{
+    public function handle(array $array, Closure $next)
+    {
+        foreach ($array as $key => $value) {
+            if ($value instanceof ValidatedDTO) {
+                $array[$key] = $value->toArray();
+            }
+        }
+
+        return $next($array);
+    }
+}


### PR DESCRIPTION
Hello everyone!

First of all I would like to thank for this handy and lightweight package to @WendellAdriel and all contributors, you saved me a lot of time.

I ran into some limitations in functionality during development and would like to suggest an option to extend it.

Let's start from example with simple data structure.

I'm receiving array of data in PascalCase:
```
{
    "FullName": "John Doe",
    "DetailedData": {
        "FirstName": "John",
        "LastName": "Doe"
    }
}
```

All of my variables and rules in DTOs is in camelCase:
```
class FullNameDTO extends ValidatedDTO
{
    public string $fullName;

    public DetailedDataDTO $detailedData;
    ...
}
```
```
class DetailedDataDTO extends ValidatedDTO
{
    public string $firstName;

    public string $lastName;
    ...
```

And I have to put this data into a table, the fields of which are in the snake_case.

The easiest and most flexible solution, in my opinion, was to pass the $data array before and $validatedData after validation through the pipeline of functions passed to the constructor. [I used the built in solution in laravel for creating pipelines.](https://laravel.com/docs/10.x/helpers#pipeline)

Here is some example of the pipe class:
```
class ConvertKeysToCamelCasePipe
{
    public function handle(array $array, Closure $next)
    {
        foreach ($array as $key => $value) {
            if ($key == ($camelCaseKey = Str::camel($key))) {
                continue;
            }

            $array[$camelCaseKey] = $value;
            unset($array[$key]);
        }

        return $next($array);
    }
}
```
You can read more about it in the documentation link above.

Creating the DTO object in this case looks like that:
```
$dto = FullNameDTO::fromJson(
    '{"FullName":"John Doe","DetailedData":{"firstName":"John","lastName":"Doe"}}',
    [
        'pipeline_before_validation' => [ConvertKeysToCamelCasePipe::class],
        'pipeline_before_export' => [ConvertKeysToSnakeCasePipe::class]
    ]
);
```

You can add any closure or pipe class to this array to process the data inside the DTO however you want.
Besides we can use $config parameter in future to extend DTO`s functionality.

Here are the responses of the methods toArray and toJson:
```
[
  "full_name" => "John Doe"
  "detailed_data" => App\DTOs\DetailedDataDTO^ {#758...}
]
```
```
{
    "full_name": "John Doe",
    "detailed_data": {
        "firstName": "John",
        "lastName": "Doe"
    }
}
```

As you can see, so far the pipeline does not affect nested DTOs. Let's fix it!
I extend the ValidatedDTO and DTOCast class a little bit so now you can pass the config variable to the nested DTO constructors if you want.
To do this you need to pass a configuration parameter to the declared DTOCast:
```
protected function casts(): array
{
    return [
        'detailedData' => new DTOCast(DetailedDataDTO::class, $this->config)
    ];
}
```

Now let's create another pipe class that will extract all nested DTOs into arrays and pass it to the constructor:
```
class ExtractNestedDTOsToArraysPipe
{
    public function handle(array $array, Closure $next)
    {
        foreach ($array as $key => $value) {
            if ($value instanceof ValidatedDTO) {
                $array[$key] = $value->toArray();
            }
        }

        return $next($array);
    }
}
```
```
$dto = FullNameDTO::fromJson(
    '{"FullName":"John Doe","DetailedData":{"firstName":"John","lastName":"Doe"}}',
    [
        'pipeline_before_validation' => [ConvertKeysToCamelCasePipe::class],
        'pipeline_before_export' => [
            ExtractNestedDTOsToArraysPipe::class,
            ConvertKeysToSnakeCasePipe::class
        ]
    ]
);
```

Let's check the answers:
```
[
  "full_name" => "John Doe"
  "detailed_data" => array:2 [
    "first_name" => "John"
    "last_name" => "Doe"
  ]
]
```
```
{
    "full_name": "John Doe",
    "detailed_data": {
        "first_name": "John",
        "last_name": "Doe"
    }
}
```

Perfect!

I added all these useful pipe classes to the src/Pipes folder so feel free to use them.

This can also be useful for clearing input data from prefixes and in a number of other cases.
The most important thing is that all this functionality is optional and will not slow down the work if you do not use it.

I find this functionality very useful and I will be glad if this PR is approved. I propose to discuss these changes. Feel free everyone to improve my changes.