### PR TITLE
The ability to use nested casts.

### DIFF
--- a/src/ValidatedDTO.php
+++ b/src/ValidatedDTO.php
@@ -278,6 +278,7 @@ abstract class ValidatedDTO implements CastsAttributes
     private function afterProcess(): void
     {
         $this->convertValidatedValue();
+        $this->fillProperties();
     }
 
     /**
@@ -384,6 +385,13 @@ abstract class ValidatedDTO implements CastsAttributes
     private function convertValidatedValue(): void
     {
         $this->validatedData = Arr::undot($this->validatedData);
+    }
+
+    private function fillProperties(): void
+    {
+        foreach ($this->validatedData as $key => $value) {
+            $this->{$key} = $value;
+        }
     }
 
     /**

--- a/src/ValidatedDTO.php
+++ b/src/ValidatedDTO.php
@@ -323,7 +323,6 @@ abstract class ValidatedDTO implements CastsAttributes
 
             if (! $this->isValidCastValue($key)) {
                 $this->validatedData[$key] = $value;
-                $this->{$key} = $value;
 
                 continue;
             }
@@ -354,7 +353,7 @@ abstract class ValidatedDTO implements CastsAttributes
      */
     private function fillDefaultValues(): void
     {
-        foreach ($this->defaults() as $key => $value) {
+        foreach ($this->getImplodedDefaults() as $key => $value) {
             if (
                 property_exists($this, $key) &&
                 ! empty($this->{$key})
@@ -364,7 +363,6 @@ abstract class ValidatedDTO implements CastsAttributes
 
             if (! $this->isValidCastValue($key)) {
                 $this->validatedData[$key] = $value;
-                $this->{$key} = $value;
 
                 continue;
             }
@@ -435,6 +433,24 @@ abstract class ValidatedDTO implements CastsAttributes
                 ),
             )
             ->rules;
+    }
+
+    private function getImplodedDefaults(): array
+    {
+        $defaults = (new DtoValidationParser($this->data))
+            ->explode(
+                DtoValidationParser::filterConditionalRules(
+                    $this->defaults(),
+                    $this->data,
+                ),
+            )
+            ->rules;
+
+        if (is_array($defaults)) {
+            return Arr::dot($defaults);
+        }
+
+        return $defaults;
     }
 
     private function getImplodedCasts(): array

--- a/src/Validations/DtoValidationParser.php
+++ b/src/Validations/DtoValidationParser.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\ValidatedDTO\Validations;
+
+use Illuminate\Validation\ValidationRuleParser;
+use WendellAdriel\ValidatedDTO\Casting\Castable;
+
+class DtoValidationParser extends ValidationRuleParser
+{
+    protected function prepareRule($rule, $attribute)
+    {
+        if ($rule instanceof Castable) {
+            return $rule;
+        }
+
+        return parent::prepareRule($rule, $attribute);
+    }
+}

--- a/tests/Datasets/NestedCastsDTOInstance.php
+++ b/tests/Datasets/NestedCastsDTOInstance.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace WendellAdriel\ValidatedDTO\Tests\Datasets;
+
+use WendellAdriel\ValidatedDTO\Casting\ArrayCast;
+use WendellAdriel\ValidatedDTO\Casting\IntegerCast;
+use WendellAdriel\ValidatedDTO\Casting\StringCast;
+use WendellAdriel\ValidatedDTO\ValidatedDTO;
+
+class NestedCastsDTOInstance extends ValidatedDTO
+{
+    public array $user;
+
+    public bool $isActive;
+
+    protected function rules(): array
+    {
+        return [
+            'user' => 'required|array',
+            'user.name' => 'required|string',
+            'user.age' => 'required|integer|gt:18',
+            'user.payments' => 'array',
+            'user.payments.*' => 'required|integer',
+        ];
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'user.payments' => [10],
+        ];
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'user' => new ArrayCast(),
+            'user.name' => new StringCast(),
+            'user.age' => new IntegerCast(),
+            'user.payments' => new ArrayCast(),
+            'user.payments.*' => new IntegerCast(),
+        ];
+    }
+}

--- a/tests/Unit/ValidatedDTOTest.php
+++ b/tests/Unit/ValidatedDTOTest.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use function Pest\Faker\faker;
 use WendellAdriel\ValidatedDTO\Exceptions\InvalidJsonException;
+use WendellAdriel\ValidatedDTO\Tests\Datasets\NestedCastsDTOInstance;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\NullableDTO;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\ValidatedDTOInstance;
 use WendellAdriel\ValidatedDTO\ValidatedDTO;
@@ -231,4 +232,73 @@ it('validates that the ValidatedDTO can be converted into an Eloquent Model', fu
         ->toBeInstanceOf(Model::class)
         ->toArray()
         ->toBe(['name' => $this->subject_name]);
+});
+
+it('validates that ValidatedDto contains nested arguments', function () {
+    $params = [
+        'user' => [
+            'name' => 'User',
+            'age' => 25,
+            'payments' => [
+                100,
+                60,
+                35,
+                70,
+            ],
+        ],
+    ];
+
+    $validatedDTO = new NestedCastsDTOInstance($params);
+
+    expect($validatedDTO)
+        ->toBeInstanceOf(ValidatedDTO::class)
+        ->and($validatedDTO->user)
+        ->toBeArray()
+        ->and($validatedDTO->user['name'])
+        ->toBeString()
+        ->and($validatedDTO->user['payments'])
+        ->toBeArray()
+        ->and($validatedDTO->user['payments'])
+        ->toHaveCount(4);
+});
+
+it('validates that ValidatedDto can casting nested arguments', function () {
+    $params = [
+        'user' => [
+            'name' => 'User',
+            'age' => 25,
+            'payments' => [
+                '100',
+                60,
+                '35',
+                '70',
+            ],
+        ],
+    ];
+
+    $validatedDTO = new NestedCastsDTOInstance($params);
+    $payments = $validatedDTO->user['payments'];
+
+    expect($payments)
+        ->each
+        ->toBeInt();
+});
+
+it('validates that ValidatedDto can use default values', function () {
+    $params = [
+        'user' => [
+            'name' => 'User',
+            'age' => 25,
+        ],
+    ];
+
+    $validatedDTO = new NestedCastsDTOInstance($params);
+    $payments = $validatedDTO->user['payments'];
+
+    expect($payments)
+        ->toHaveCount(1)
+        ->and($payments)
+        ->toHaveKey(0)
+        ->and($payments[0])
+        ->toEqual(10);
 });


### PR DESCRIPTION
Hi. I noticed that DTO does not change the types of nested arguments in a class, as it is implemented in validation in Laravel. If it is necessary for all values in array to be of the same type, it would be nice to use a similar syntax.
For example, validation allows the value `"100"` when the `integer` rule is specified in the validation, but I need exactly values of type integer in DTO. The current implementation ignores such a description.
I have decided to implement the ability to describe the structure of casts in a similar way:
```
protected function rules(): array
{
    return [
        'user' => 'required|array',
        'user.name' => 'required|string',
        'user.age' => 'required|integer|gt:18',
        'user.payments' => 'array',
        'user.payments.*' => 'required|integer',
    ];
}

protected function casts(): array
{
    return [
        'user' => new ArrayCast(),
        'user.name' => new StringCast(),
        'user.age' => new IntegerCast(),
        'user.payments' => new ArrayCast(),
        'user.payments.*' => new IntegerCast(),
    ];
}

protected function defaults(): array
{
    return [
        'user.payments' => [10],
    ];
}
```
