### PR TITLE
Add feature to map data

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - **Type Casting** out-of-the-box for your DTOs properties
 - Support casting of **nested data**
 - Easily create **custom Type Casters** for your own needs
+- Custom Data Mapping
 
 ## Installation
 
@@ -424,6 +425,46 @@ $dto->toModel(\App\Models\User::class);
 // }
 
 ```
+
+## Mapping DTO properties
+
+### Mapping data before validation
+
+Sometimes the data you have to validate is not the same you want in your DTO. You can use the `mapBeforeValidation`
+method to map your data before the validation and the DTO instantiation occurs:
+
+```php
+protected function mapBeforeValidation(): array
+{
+    return [
+        'full_name' => 'name',
+    ];
+}
+```
+
+The code above will map the `full_name` property to the `name` property before the validation and the DTO instantiation.
+So your Request/Array/etc can have a `full_name` property and your DTO will have a `name` property instead.
+
+### Mapping data before export
+
+Sometimes the data you have in your DTO is not the same you want to your Model, Array, JSON. You can use the `mapBeforeExport`
+method to map your data before exporting your DTO to another structure:
+
+```php
+protected function mapBeforeExport(): array
+{
+    return [
+        'name' => 'username',
+    ];
+}
+```
+
+The code above will map the `name` property to the `username` property before exporting your DTO to another structure.
+So the result structure will have a `username` property instead of a `name` property.
+
+You can combine both methods to map your data before validation and before export.
+If you combine the both examples above your request will have a `full_name` property, your DTO will have a `name` property
+and when exported the result will have a `username` property.
 
 ## Customizing Error Messages, Attributes and Exceptions
 

--- a/tests/Datasets/MapBeforeExportDTO.php
+++ b/tests/Datasets/MapBeforeExportDTO.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WendellAdriel\ValidatedDTO\Tests\Datasets;
+
+use WendellAdriel\ValidatedDTO\ValidatedDTO;
+
+class MapBeforeExportDTO extends ValidatedDTO
+{
+    public string $name;
+
+    protected function rules(): array
+    {
+        return [
+            'name' => ['required', 'string'],
+        ];
+    }
+
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    protected function casts(): array
+    {
+        return [];
+    }
+
+    protected function mapBeforeExport(): array
+    {
+        return [
+            'name' => 'username',
+        ];
+    }
+}

--- a/tests/Datasets/MapBeforeValidationDTO.php
+++ b/tests/Datasets/MapBeforeValidationDTO.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WendellAdriel\ValidatedDTO\Tests\Datasets;
+
+use WendellAdriel\ValidatedDTO\ValidatedDTO;
+
+class MapBeforeValidationDTO extends ValidatedDTO
+{
+    public string $name;
+
+    protected function rules(): array
+    {
+        return [
+            'name' => ['required', 'string'],
+        ];
+    }
+
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    protected function casts(): array
+    {
+        return [];
+    }
+
+    protected function mapBeforeValidation(): array
+    {
+        return [
+            'full_name' => 'name',
+        ];
+    }
+}

--- a/tests/Datasets/MapDataDTO.php
+++ b/tests/Datasets/MapDataDTO.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace WendellAdriel\ValidatedDTO\Tests\Datasets;
+
+use WendellAdriel\ValidatedDTO\ValidatedDTO;
+
+class MapDataDTO extends ValidatedDTO
+{
+    public string $name;
+
+    protected function rules(): array
+    {
+        return [
+            'name' => ['required', 'string'],
+        ];
+    }
+
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    protected function casts(): array
+    {
+        return [];
+    }
+
+    protected function mapBeforeValidation(): array
+    {
+        return [
+            'full_name' => 'name',
+        ];
+    }
+
+    protected function mapBeforeExport(): array
+    {
+        return [
+            'name' => 'username',
+        ];
+    }
+}

--- a/tests/Unit/ValidatedDTOTest.php
+++ b/tests/Unit/ValidatedDTOTest.php
@@ -7,6 +7,9 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use function Pest\Faker\faker;
 use WendellAdriel\ValidatedDTO\Exceptions\InvalidJsonException;
+use WendellAdriel\ValidatedDTO\Tests\Datasets\MapBeforeExportDTO;
+use WendellAdriel\ValidatedDTO\Tests\Datasets\MapBeforeValidationDTO;
+use WendellAdriel\ValidatedDTO\Tests\Datasets\MapDataDTO;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\NullableDTO;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\ValidatedDTOInstance;
 use WendellAdriel\ValidatedDTO\ValidatedDTO;
@@ -231,4 +234,37 @@ it('validates that the ValidatedDTO can be converted into an Eloquent Model', fu
         ->toBeInstanceOf(Model::class)
         ->toArray()
         ->toBe(['name' => $this->subject_name]);
+});
+
+it('maps data before validation', function () {
+    $dto = MapBeforeValidationDTO::fromArray(['full_name' => $this->subject_name]);
+
+    expect($dto->full_name)
+        ->toBeNull()
+        ->and($dto->name)
+        ->toBe($this->subject_name);
+});
+
+it('maps data before export', function () {
+    $dto = MapBeforeExportDTO::fromArray(['name' => $this->subject_name]);
+
+    expect($dto->name)
+        ->toBe($this->subject_name)
+        ->and($dto->username)
+        ->toBeNull()
+        ->and($dto->toArray())
+        ->toBe(['username' => $this->subject_name]);
+});
+
+it('maps data before validation and before export', function () {
+    $dto = MapDataDTO::fromArray(['full_name' => $this->subject_name]);
+
+    expect($dto->full_name)
+        ->toBeNull()
+        ->and($dto->name)
+        ->toBe($this->subject_name)
+        ->and($dto->username)
+        ->toBeNull()
+        ->and($dto->toArray())
+        ->toBe(['username' => $this->subject_name]);
 });


### PR DESCRIPTION
This PR is an alternative to #27 

This will add the feature to map the data before instantiating a DTO and before exporting the DTO to another structure like an array or Model.

This adds two new methods for that:

- `mapBeforeValidation`
- `mapBeforeExport`

If you want to map the data you just need to implement these methods.
Example:

```php
protected function mapBeforeValidation(): array
{
    return [
        'full_name' => 'name',
    ];
}

protected function mapBeforeExport(): array
{
    return [
        'name' => 'username',
    ];
}
```