### PR TITLE
Add Support  for callback function for casting

### DIFF
--- a/src/SimpleDTO.php
+++ b/src/SimpleDTO.php
@@ -345,13 +345,13 @@ abstract class SimpleDTO implements CastsAttributes
     /**
      *  Check cast is callable or instance of Castable.
      */
-    protected function getCast($cast, string $key, mixed $value): mixed
+    protected function getCast(mixed $cast, string $key, mixed $value): mixed
     {
-        if($cast instanceof  \WendellAdriel\ValidatedDTO\Casting\Castable){
+        if ($cast instanceof \WendellAdriel\ValidatedDTO\Casting\Castable) {
             return $cast->cast($key, $value);
         }
 
-        return  is_callable($cast) ? $cast($key, $value) : $value;
+        return is_callable($cast) ? $cast($key, $value) : $value;
     }
 
     protected function shouldReturnNull(string $key, mixed $value): bool

--- a/src/SimpleDTO.php
+++ b/src/SimpleDTO.php
@@ -277,13 +277,9 @@ abstract class SimpleDTO implements CastsAttributes
                     continue;
                 }
 
-                if (! ($casts[$key] instanceof Castable)) {
-                    throw new CastTargetException($key);
-                }
-
                 $formatted = $this->shouldReturnNull($key, $value)
                     ? null
-                    : $casts[$key]->cast($key, $value);
+                    : $this->getCast($casts[$key], $key, $value);
                 $this->{$key} = $formatted;
                 $this->validatedData[$key] = $formatted;
             }
@@ -331,13 +327,9 @@ abstract class SimpleDTO implements CastsAttributes
                     continue;
                 }
 
-                if (! ($casts[$key] instanceof Castable)) {
-                    throw new CastTargetException($key);
-                }
-
                 $result[$key] = $this->shouldReturnNull($key, $value)
                     ? null
-                    : $casts[$key]->cast($key, $value);
+                    : $this->getCast($casts[$key], $key, $value);
             }
         }
 
@@ -348,6 +340,18 @@ abstract class SimpleDTO implements CastsAttributes
         }
 
         return $result;
+    }
+
+    /**
+     *  Check cast is callable or instance of Castable.
+     */
+    protected function getCast($cast, string $key, mixed $value): mixed
+    {
+        if($cast instanceof  \WendellAdriel\ValidatedDTO\Casting\Castable){
+            return $cast->cast($key, $value);
+        }
+
+        return  is_callable($cast) ? $cast($key, $value) : $value;
     }
 
     protected function shouldReturnNull(string $key, mixed $value): bool

--- a/src/SimpleDTO.php
+++ b/src/SimpleDTO.php
@@ -279,7 +279,7 @@ abstract class SimpleDTO implements CastsAttributes
 
                 $formatted = $this->shouldReturnNull($key, $value)
                     ? null
-                    : $this->getCast($casts[$key], $key, $value);
+                    : $this->castValue($casts[$key], $key, $value);
                 $this->{$key} = $formatted;
                 $this->validatedData[$key] = $formatted;
             }
@@ -329,7 +329,7 @@ abstract class SimpleDTO implements CastsAttributes
 
                 $result[$key] = $this->shouldReturnNull($key, $value)
                     ? null
-                    : $this->getCast($casts[$key], $key, $value);
+                    : $this->castValue($casts[$key], $key, $value);
             }
         }
 
@@ -343,15 +343,19 @@ abstract class SimpleDTO implements CastsAttributes
     }
 
     /**
-     *  Check cast is callable or instance of Castable.
+     * @throws \WendellAdriel\ValidatedDTO\Exceptions\CastTargetException
      */
-    protected function getCast(mixed $cast, string $key, mixed $value): mixed
+    protected function castValue(mixed $cast, string $key, mixed $value): mixed
     {
-        if ($cast instanceof \WendellAdriel\ValidatedDTO\Casting\Castable) {
+        if ($cast instanceof Castable) {
             return $cast->cast($key, $value);
         }
 
-        return is_callable($cast) ? $cast($key, $value) : $value;
+        if (! is_callable($cast)) {
+            throw new CastTargetException($key);
+        }
+
+        return $cast($key, $value);
     }
 
     protected function shouldReturnNull(string $key, mixed $value): bool

--- a/src/ValidatedDTO.php
+++ b/src/ValidatedDTO.php
@@ -60,7 +60,7 @@ abstract class ValidatedDTO extends SimpleDTO
 
                 $result[$key] = $this->shouldReturnNull($key, $value)
                     ? null
-                    : $this->getCast($casts[$key], $key, $value);
+                    : $this->castValue($casts[$key], $key, $value);
             }
         }
 

--- a/src/ValidatedDTO.php
+++ b/src/ValidatedDTO.php
@@ -58,13 +58,9 @@ abstract class ValidatedDTO extends SimpleDTO
                     continue;
                 }
 
-                if (! ($casts[$key] instanceof Castable)) {
-                    throw new CastTargetException($key);
-                }
-
                 $result[$key] = $this->shouldReturnNull($key, $value)
                     ? null
-                    : $casts[$key]->cast($key, $value);
+                    : $this->getCast($casts[$key], $key, $value);
             }
         }
 

--- a/tests/Datasets/CallableCastingDTOInstance.php
+++ b/tests/Datasets/CallableCastingDTOInstance.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\ValidatedDTO\Tests\Datasets;
+
+use WendellAdriel\ValidatedDTO\Casting\DTOCast;
+use WendellAdriel\ValidatedDTO\Exceptions\CastException;
+use WendellAdriel\ValidatedDTO\SimpleDTO;
+
+class CallableCastingDTOInstance extends SimpleDTO
+{
+    public SimpleNameDTO $name;
+
+    public ?int $age = null;
+
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'name' => new DTOCast(SimpleNameDTO::class),
+            'age' => function (string $property, mixed $value) {
+                if (! is_numeric($value)) {
+                    throw new CastException($property);
+                }
+
+                return (int) $value;
+            },
+        ];
+    }
+}

--- a/tests/Unit/CallableCastTest.php
+++ b/tests/Unit/CallableCastTest.php
@@ -15,12 +15,12 @@ it('casts property to object using callback function')
                 throw new CastException($property);
             }
 
-            return (object) $value;
+            return $value;
         };
 
         return $callback(test_property(), '{"name": "John Doe", "email": "john.doe@example.com"}');
     })
-    ->toBe((object) ['name' => 'John Doe', 'email' => 'john.doe@example.com']);
+    ->toBe(['name' => 'John Doe', 'email' => 'john.doe@example.com']);
 
 it('casts property to uppercase using callback function')
     ->expect(function () {

--- a/tests/Unit/CallbackFunctionCastTest.php
+++ b/tests/Unit/CallbackFunctionCastTest.php
@@ -20,8 +20,7 @@ it('casts property to object using callback function')
 
         return $callback(test_property(), '{"name": "John Doe", "email": "john.doe@example.com"}');
     })
-    ->toBeObject()
-    ->toEqual((object) ['name' => 'John Doe', 'email' => 'john.doe@example.com']);
+    ->toBe((object) ['name' => 'John Doe', 'email' => 'john.doe@example.com']);
 
 it('casts property to uppercase using callback function')
     ->expect(function () {
@@ -29,4 +28,4 @@ it('casts property to uppercase using callback function')
 
         return $callback(test_property(), 'John Doe');
     })
-    ->toEqual('JOHN DOE');
+    ->toBe('JOHN DOE');

--- a/tests/Unit/CallbackFunctionCastTest.php
+++ b/tests/Unit/CallbackFunctionCastTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use WendellAdriel\ValidatedDTO\Exceptions\CastException;
+
+it('casts property to object using callback function')
+    ->expect(function () {
+        $callback = function (string $property, mixed $value) {
+            if (is_string($value)) {
+                $value = json_decode($value, true);
+            }
+
+            if (! is_array($value)) {
+                throw new CastException($property);
+            }
+
+            return (object) $value;
+        };
+
+        return $callback(test_property(), '{"name": "John Doe", "email": "john.doe@example.com"}');
+    })
+    ->toBeObject()
+    ->toEqual((object) ['name' => 'John Doe', 'email' => 'john.doe@example.com']);
+
+it('casts property to uppercase using callback function')
+    ->expect(function () {
+        $callback = fn (string $property, mixed $value) => strtoupper($value);
+
+        return $callback(test_property(), 'John Doe');
+    })
+    ->toEqual('JOHN DOE');

--- a/tests/Unit/SimpleDTOTest.php
+++ b/tests/Unit/SimpleDTOTest.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use function Pest\Faker\faker;
 use WendellAdriel\ValidatedDTO\Exceptions\InvalidJsonException;
 use WendellAdriel\ValidatedDTO\SimpleDTO;
+use WendellAdriel\ValidatedDTO\Tests\Datasets\CallableCastingDTOInstance;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\SimpleDTOInstance;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\SimpleMapBeforeExportDTO;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\SimpleMapBeforeValidationDTO;
@@ -294,4 +295,23 @@ it('maps nested data to flat data before export', function () {
         ->toBe('Doe')
         ->and($user->email)
         ->toBe('john.doe@example.com');
+});
+
+it('custom casting with callback function', function () {
+    $dto = CallableCastingDTOInstance::fromArray([
+        'name' => [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+        ],
+        'age' => '30',
+    ]);
+
+    expect($dto->name)
+        ->toBeInstanceOf(SimpleNameDTO::class)
+        ->and($dto->name->first_name)
+        ->toBe('John')
+        ->and($dto->name->last_name)
+        ->toBe('Doe')
+        ->and($dto->age)
+        ->toBe(30);
 });

--- a/tests/Unit/SimpleDTOTest.php
+++ b/tests/Unit/SimpleDTOTest.php
@@ -297,7 +297,7 @@ it('maps nested data to flat data before export', function () {
         ->toBe('john.doe@example.com');
 });
 
-it('custom casting with callback function', function () {
+it('casts properties with castable classes and callables', function () {
     $dto = CallableCastingDTOInstance::fromArray([
         'name' => [
             'first_name' => 'John',


### PR DESCRIPTION
#### This pull request extends the functionality of the Laravel Validated DTO package by introducing support for callback functions in custom casting. 

Currently, the package allows for custom casting operations by creating separate classes for each custom cast. However, there are cases where a more lightweight and concise approach is desired, where a callback function can be used directly for custom casting logic.


<img width="1140" alt="image" src="https://github.com/WendellAdriel/laravel-validated-dto/assets/11002290/ecbe5b3f-6486-4588-8f45-0d7b00a5f2b2">

<img width="1140" alt="image" src="https://github.com/WendellAdriel/laravel-validated-dto/assets/11002290/c1f32fa7-6dc2-4eca-8677-874400a912fc">
