### PR TITLE
Fixed an issue with file validation

### DIFF
--- a/src/SimpleDTO.php
+++ b/src/SimpleDTO.php
@@ -9,6 +9,7 @@ use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\ValidationException;
 use ReflectionClass;
@@ -430,7 +431,7 @@ abstract class SimpleDTO implements BaseDTO, CastsAttributes
             $value instanceof Collection ||
             $value instanceof ValidatedDTO ||
             $value instanceof Model ||
-            is_object($value);
+            (is_object($value) && ! ($value instanceof UploadedFile));
     }
 
     private function formatArrayableValue(mixed $value): array|int|string

--- a/tests/Datasets/ValidatedFileDTO.php
+++ b/tests/Datasets/ValidatedFileDTO.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\ValidatedDTO\Tests\Datasets;
+
+use Illuminate\Http\UploadedFile;
+use WendellAdriel\ValidatedDTO\ValidatedDTO;
+
+class ValidatedFileDTO extends ValidatedDTO
+{
+    public UploadedFile $file;
+
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    protected function casts(): array
+    {
+        return [];
+    }
+
+    protected function rules(): array
+    {
+        return [
+            'file' => 'required|file|mimes:jpg,jpeg,png',
+        ];
+    }
+}

--- a/tests/Unit/ValidatedDTOTest.php
+++ b/tests/Unit/ValidatedDTOTest.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Validation\ValidationException;
 use WendellAdriel\ValidatedDTO\Exceptions\InvalidJsonException;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\DummyBackedEnum;
@@ -25,6 +26,7 @@ use WendellAdriel\ValidatedDTO\Tests\Datasets\UserNestedCollectionDTO;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\UserNestedDTO;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\ValidatedDTOInstance;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\ValidatedEnumDTO;
+use WendellAdriel\ValidatedDTO\Tests\Datasets\ValidatedFileDTO;
 use WendellAdriel\ValidatedDTO\ValidatedDTO;
 
 beforeEach(function () {
@@ -449,3 +451,17 @@ it('maps nested data to flat data before export', function () {
         ->and($user->email)
         ->toBe('john.doe@example.com');
 });
+
+it('validates that ValidatedDTO can be instantiated with file validation rules', function () {
+    $uploadedFile = UploadedFile::fake()->image('avatar.jpg');
+    $validatedDTO = ValidatedFileDTO::fromArray(['file' => $uploadedFile]);
+
+    expect($validatedDTO->validator->passes())
+        ->toBeTrue();
+});
+
+it('validates that ValidateDTO cannot be instantiated with wrong mime type')
+->expect(function () {
+    $uploadedFile = UploadedFile::fake()->create('document.pdf');
+    ValidatedFileDTO::fromArray(['file' => $uploadedFile]);
+})->throws(ValidationException::class);

--- a/tests/Unit/ValidatedDTOTest.php
+++ b/tests/Unit/ValidatedDTOTest.php
@@ -461,7 +461,7 @@ it('validates that ValidatedDTO can be instantiated with file validation rules',
 });
 
 it('validates that ValidateDTO cannot be instantiated with wrong mime type')
-->expect(function () {
-    $uploadedFile = UploadedFile::fake()->create('document.pdf');
-    ValidatedFileDTO::fromArray(['file' => $uploadedFile]);
-})->throws(ValidationException::class);
+    ->expect(function () {
+        $uploadedFile = UploadedFile::fake()->create('document.pdf');
+        ValidatedFileDTO::fromArray(['file' => $uploadedFile]);
+    })->throws(ValidationException::class);


### PR DESCRIPTION
This PR fixes an issue with uploaded file validation described here: https://github.com/WendellAdriel/laravel-validated-dto/discussions/63

Before validation, an `UploadedFile` instance gets casted to array and passed to Validator. Validator performs a `instance of UploadedFile` check, and the validation fails, because of this cast to array.

The PR adds an additional check to `SimpleDTO`'s `isArrayable()` method, that ensures that `UploadedFile` object is not considered arrayable value and it will not be passed to `formatArrayableValue()` method for further array casting.

Unit tests for file validation were also added.