### PR TITLE
read custom stubs in case developer require custom stubs

### DIFF
--- a/src/Console/Commands/MakeDTOCommand.php
+++ b/src/Console/Commands/MakeDTOCommand.php
@@ -68,7 +68,7 @@ final class MakeDTOCommand extends GeneratorCommand
      */
     protected function resolveStubPath(string $stub): string
     {
-        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+        return file_exists($customPath = $this->laravel->basePath(trim("stubs/{$stub}", '/')))
             ? $customPath
             : __DIR__ . '/../stubs/' . $stub;
     }


### PR DESCRIPTION
Dear Contributors,

I encountered a problem while attempting to customize the Data Transfer Object (DTO) stubs. Specifically, when generating a DTO, the system did not utilize my custom stubs, but rather sought them at the project's root directory, bypassing the intended stubs folder at the root of my project. To address this issue, I have made adjustments to the MakeDTOCommand.




