### PR TITLE
fix number cast when post empty string

### DIFF
--- a/src/Casting/FloatCast.php
+++ b/src/Casting/FloatCast.php
@@ -13,7 +13,7 @@ final class FloatCast implements Castable
      */
     public function cast(string $property, mixed $value): float
     {
-        if (! is_numeric($value)) {
+        if (! is_numeric($value) && $value !== '') {
             throw new CastException($property);
         }
 

--- a/src/Casting/IntegerCast.php
+++ b/src/Casting/IntegerCast.php
@@ -13,7 +13,7 @@ final class IntegerCast implements Castable
      */
     public function cast(string $property, mixed $value): int
     {
-        if (! is_numeric($value)) {
+        if (! is_numeric($value) && $value !== '') {
             throw new CastException($property);
         }
 


### PR DESCRIPTION
#[Rules(rules: ['sometimes', 'integer'])]
#[Cast(type: IntegerCast::class)]
public int $userId;

validation is passed when front-end post {"userId":''}, but throw CastException