### PR TITLE
Clearing data property after DTO validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /.idea
 /.vagrant
 /.phpstorm.*
+/.phpunit.cache
 composer.lock
 .phpunit.result.cache

--- a/src/Attributes/Cast.php
+++ b/src/Attributes/Cast.php
@@ -18,6 +18,5 @@ final class Cast
          * @var class-string
          */
         public ?string $param = null,
-    ) {
-    }
+    ) {}
 }

--- a/src/Attributes/DefaultValue.php
+++ b/src/Attributes/DefaultValue.php
@@ -11,6 +11,5 @@ final class DefaultValue
 {
     public function __construct(
         public mixed $value,
-    ) {
-    }
+    ) {}
 }

--- a/src/Attributes/Map.php
+++ b/src/Attributes/Map.php
@@ -12,6 +12,5 @@ final class Map
     public function __construct(
         public ?string $data = null,
         public ?string $transform = null,
-    ) {
-    }
+    ) {}
 }

--- a/src/Attributes/Rules.php
+++ b/src/Attributes/Rules.php
@@ -18,6 +18,5 @@ final class Rules
          * @var array<string, string>
          */
         public array $messages = [],
-    ) {
-    }
+    ) {}
 }

--- a/src/Casting/ArrayCast.php
+++ b/src/Casting/ArrayCast.php
@@ -6,9 +6,7 @@ namespace WendellAdriel\ValidatedDTO\Casting;
 
 final class ArrayCast implements Castable
 {
-    public function __construct(private ?Castable $type = null)
-    {
-    }
+    public function __construct(private ?Castable $type = null) {}
 
     public function cast(string $property, mixed $value): array
     {

--- a/src/Casting/CarbonCast.php
+++ b/src/Casting/CarbonCast.php
@@ -13,8 +13,7 @@ final class CarbonCast implements Castable
     public function __construct(
         private ?string $timezone = null,
         private ?string $format = null
-    ) {
-    }
+    ) {}
 
     /**
      * @throws CastException

--- a/src/Casting/CarbonImmutableCast.php
+++ b/src/Casting/CarbonImmutableCast.php
@@ -13,8 +13,7 @@ final class CarbonImmutableCast implements Castable
     public function __construct(
         private ?string $timezone = null,
         private ?string $format = null
-    ) {
-    }
+    ) {}
 
     /**
      * @throws CastException

--- a/src/Casting/CollectionCast.php
+++ b/src/Casting/CollectionCast.php
@@ -8,9 +8,7 @@ use Illuminate\Support\Collection;
 
 final class CollectionCast implements Castable
 {
-    public function __construct(private ?Castable $type = null)
-    {
-    }
+    public function __construct(private ?Castable $type = null) {}
 
     public function cast(string $property, mixed $value): Collection
     {

--- a/src/Casting/DTOCast.php
+++ b/src/Casting/DTOCast.php
@@ -12,9 +12,7 @@ use WendellAdriel\ValidatedDTO\SimpleDTO;
 
 final class DTOCast implements Castable
 {
-    public function __construct(private string $dtoClass)
-    {
-    }
+    public function __construct(private string $dtoClass) {}
 
     /**
      * @throws CastException|CastTargetException|ValidationException

--- a/src/Casting/EnumCast.php
+++ b/src/Casting/EnumCast.php
@@ -14,9 +14,7 @@ final class EnumCast implements Castable
     /**
      * @param  class-string<UnitEnum|BackedEnum>  $enum
      */
-    public function __construct(protected string $enum)
-    {
-    }
+    public function __construct(protected string $enum) {}
 
     /**
      * @throws CastException|CastTargetException

--- a/src/Casting/ModelCast.php
+++ b/src/Casting/ModelCast.php
@@ -11,9 +11,7 @@ use WendellAdriel\ValidatedDTO\Exceptions\CastTargetException;
 
 final class ModelCast implements Castable
 {
-    public function __construct(private string $modelClass)
-    {
-    }
+    public function __construct(private string $modelClass) {}
 
     /**
      * @throws CastException|CastTargetException

--- a/src/SimpleDTO.php
+++ b/src/SimpleDTO.php
@@ -191,6 +191,8 @@ abstract class SimpleDTO implements BaseDTO, CastsAttributes
                 $this->validatedData[$key] = $formatted;
             }
         }
+
+        $this->data = [];
     }
 
     protected function failedValidation(): void

--- a/src/Support/ResourceCollection.php
+++ b/src/Support/ResourceCollection.php
@@ -22,8 +22,7 @@ final class ResourceCollection implements Responsable
         private string $dtoClass,
         private int $status = 200,
         private array $headers = []
-    ) {
-    }
+    ) {}
 
     /**
      * @param  Request  $request

--- a/tests/Unit/SimpleDTOTest.php
+++ b/tests/Unit/SimpleDTOTest.php
@@ -108,9 +108,7 @@ it('validates that a SimpleDTO can be instantiated from Command arguments', func
             = 'test:command
             {name : The name of the user}';
 
-        public function __invoke()
-        {
-        }
+        public function __invoke() {}
     };
 
     Application::starting(function ($artisan) use ($command) {
@@ -132,9 +130,7 @@ it('validates that a SimpleDTO can be instantiated from Command options', functi
             = 'test:command
             {--name= : The name of the user}';
 
-        public function __invoke()
-        {
-        }
+        public function __invoke() {}
     };
 
     Application::starting(function ($artisan) use ($command) {
@@ -157,9 +153,7 @@ it('validates that a SimpleDTO can be instantiated from a Command', function () 
             {name : The name of the user}
             {--age= : The age of the user}';
 
-        public function __invoke()
-        {
-        }
+        public function __invoke() {}
     };
 
     Application::starting(function ($artisan) use ($command) {

--- a/tests/Unit/ValidatedDTOTest.php
+++ b/tests/Unit/ValidatedDTOTest.php
@@ -140,9 +140,7 @@ it('validates that a ValidatedDTO can be instantiated from Command arguments', f
             = 'test:command
             {name : The name of the user}';
 
-        public function __invoke()
-        {
-        }
+        public function __invoke() {}
     };
 
     Application::starting(function ($artisan) use ($command) {
@@ -166,9 +164,7 @@ it('validates that a ValidatedDTO can be instantiated from Command options', fun
             = 'test:command
             {--name= : The name of the user}';
 
-        public function __invoke()
-        {
-        }
+        public function __invoke() {}
     };
 
     Application::starting(function ($artisan) use ($command) {
@@ -193,9 +189,7 @@ it('validates that a ValidatedDTO can be instantiated from a Command', function 
             {name : The name of the user}
             {--age= : The age of the user}';
 
-        public function __invoke()
-        {
-        }
+        public function __invoke() {}
     };
 
     Application::starting(function ($artisan) use ($command) {


### PR DESCRIPTION
This fixes the issue reported in #77 
After the DTO is validated, there's no need to keep the data in the `$data` property.
This PR fixes this by resetting the value of the `$data` property to an empty array after the validation is applied.