### PR TITLE
Fix issue with toArray

### DIFF
--- a/src/SimpleDTO.php
+++ b/src/SimpleDTO.php
@@ -401,6 +401,10 @@ abstract class SimpleDTO implements BaseDTO, CastsAttributes
                 ? $mapping[$key]
                 : $key;
 
+            if (isset($this->{$key}) && $value !== $this->{$key}) {
+                $value = $this->{$key};
+            }
+
             $mappedData[$property] = $this->isArrayable($value)
                 ? $this->formatArrayableValue($value)
                 : $value;

--- a/tests/Unit/SimpleDTOTest.php
+++ b/tests/Unit/SimpleDTOTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use WendellAdriel\ValidatedDTO\Exceptions\InvalidJsonException;
 use WendellAdriel\ValidatedDTO\SimpleDTO;
+use WendellAdriel\ValidatedDTO\Tests\Datasets\AttributesDTO;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\CallableCastingDTOInstance;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\SimpleDTOInstance;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\SimpleMapBeforeExportDTO;
@@ -300,4 +301,16 @@ it('casts properties with castable classes and callables', function () {
         ->toBe('Doe')
         ->and($dto->age)
         ->toBe(30);
+});
+
+it('checks that update for property reflects while converting DTO', function () {
+    $dto = AttributesDTO::fromArray([
+        'age' => 18,
+        'doc' => 'test',
+    ]);
+
+    $dto->age = 20;
+
+    expect($dto->age)->toBe(20)
+        ->and($dto->toArray())->toBe(['age' => 20, 'doc' => 'test']);
 });


### PR DESCRIPTION
This fixes the issue described in #78 
When using `toArray` (or any other method to transform the DTO into another structure), there was an inconsistency with the data from the DTO property and the resulting structure.

This PR introduces a fix and a test case to cover the scenario.