### PR TITLE
Switched buildDataForExport from private to public for custom DataTransformers

### DIFF
--- a/src/SimpleDTO.php
+++ b/src/SimpleDTO.php
@@ -288,6 +288,16 @@ abstract class SimpleDTO implements BaseDTO, CastsAttributes
         ];
     }
 
+    protected function buildDataForExport(): array
+    {
+        $mapping = [
+            ...$this->mapToTransform(),
+            ...$this->dtoMapTransform,
+        ];
+
+        return $this->mapDTOData($mapping, $this->validatedData);
+    }
+
     private function buildAttributesData(): void
     {
         $publicProperties = $this->getPublicProperties();
@@ -370,16 +380,6 @@ abstract class SimpleDTO implements BaseDTO, CastsAttributes
         ];
 
         return $this->mapDTOData($mapping, $data);
-    }
-
-    private function buildDataForExport(): array
-    {
-        $mapping = [
-            ...$this->mapToTransform(),
-            ...$this->dtoMapTransform,
-        ];
-
-        return $this->mapDTOData($mapping, $this->validatedData);
     }
 
     private function mapDTOData(array $mapping, array $data): array


### PR DESCRIPTION
We talked about that change in https://github.com/WendellAdriel/laravel-validated-dto/issues/81 and I did a PR for it. I also moved the protected function to all the other protected functions. Let me know if you want me to change anything.

I also added an explanation to the [docs](https://github.com/WendellAdriel/laravel-validated-dto-docs/pull/6).

🦄