### PR TITLE
Preserve timezone offset for Carbon casts

### DIFF
--- a/src/SimpleDTO.php
+++ b/src/SimpleDTO.php
@@ -446,7 +446,7 @@ abstract class SimpleDTO implements BaseDTO, CastsAttributes
             is_array($value) => $value,
             $value instanceof BackedEnum => $value->value,
             $value instanceof UnitEnum => $value->name,
-            $value instanceof Carbon || $value instanceof CarbonImmutable => $value->toISOString(),
+            $value instanceof Carbon || $value instanceof CarbonImmutable => $value->toISOString(true),
             $value instanceof Collection => $this->transformCollectionToArray($value),
             $value instanceof Model => $this->transformModelToArray($value),
             $value instanceof SimpleDTO => $this->transformDTOToArray($value),

--- a/tests/Unit/ValidatedDTOTest.php
+++ b/tests/Unit/ValidatedDTOTest.php
@@ -351,8 +351,8 @@ it('validates that the ValidatedDTO with Enums and Carbon properties can be corr
         ->toBe([
             'unitEnum' => 'ONE',
             'backedEnum' => 'bar',
-            'carbon' => '2023-10-16T00:00:00.000000Z',
-            'carbonImmutable' => '2023-10-15T00:00:00.000000Z',
+            'carbon' => '2023-10-16T00:00:00.000000+00:00',
+            'carbonImmutable' => '2023-10-15T00:00:00.000000+00:00',
         ]);
 });
 


### PR DESCRIPTION
Currently when defining a Carbon object on the Dto the timezone offset gets lost as the object is serialised to a string. Then a new Carbon object gets created from the serialised string missing the offset.

Given a Carbon object:
```php
$date = now() // date: 2024-07-19 20:07:42.470299 Europe/Dublin (+01:00)
echo $date->toDateTimeString(); // 2024-07-19 20:09:12
```

Given the DTO definition:
```php
class TestDTO extends ValidatedDTO
{
    public Carbon $date;

    protected function rules(): array
    {
        return [
            'date' => ['required'],
        ];
    }

    protected function defaults(): array
    {
        return [];
    }

    protected function casts(): array
    {
        return [
            'date' => new CarbonCast(),
        ];
    }

    protected function mapData(): array
    {
        return [];
    }
}
```

Creating the DTO:
```php
$dto = new TestDTO([
    'date' => $date,
]);
```

Accessing date:
```php
echo $dto->date->toDateTimeString() // 2024-07-19 19:09:12
```
**Returns an incorrect time**. The 1 hour offset Dublin/Europe to UTC gets lost. Adding "Dublin/Europe" to CarbonCast does not help. The problem is in [WendellAdriel\ValidatedDTO\SimpleDTO L:449](https://github.com/WendellAdriel/laravel-validated-dto/blob/102c311a46c6693ed0d8febb93c53758d750603d/src/SimpleDTO.php#L449) as package doesn't preserve the Carbon object all the way but serialises it to a string before re-creating the Carbon object again.

Adding `true` to `->toISOString(true)` sets `$keepOffset` and preserves the timezone offset.

I had to adjust the test to make this work, however, I don't think this is a breaking change by any means as the output is the same.
