### PR TITLE
Added support for Arrayable

### DIFF
--- a/src/SimpleDTO.php
+++ b/src/SimpleDTO.php
@@ -8,6 +8,7 @@ use BackedEnum;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
@@ -434,6 +435,7 @@ abstract class SimpleDTO implements BaseDTO, CastsAttributes
     private function isArrayable(mixed $value): bool
     {
         return is_array($value) ||
+            $value instanceof Arrayable ||
             $value instanceof Collection ||
             $value instanceof ValidatedDTO ||
             $value instanceof Model ||
@@ -450,6 +452,7 @@ abstract class SimpleDTO implements BaseDTO, CastsAttributes
             $value instanceof Collection => $this->transformCollectionToArray($value),
             $value instanceof Model => $this->transformModelToArray($value),
             $value instanceof SimpleDTO => $this->transformDTOToArray($value),
+            $value instanceof Arrayable => $value->toArray(),
             is_object($value) => (array) $value,
             default => [],
         };

--- a/tests/Datasets/ArrayableObject.php
+++ b/tests/Datasets/ArrayableObject.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WendellAdriel\ValidatedDTO\Tests\Datasets;
 
 use Illuminate\Contracts\Support\Arrayable;

--- a/tests/Datasets/ArrayableObject.php
+++ b/tests/Datasets/ArrayableObject.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace WendellAdriel\ValidatedDTO\Tests\Datasets;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class ArrayableObject implements Arrayable
+{
+    public function key(): string
+    {
+        return 'arrayable-object-key';
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'key' => $this->key(),
+        ];
+    }
+}

--- a/tests/Datasets/ArrayableObjectCast.php
+++ b/tests/Datasets/ArrayableObjectCast.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\ValidatedDTO\Tests\Datasets;
+
+use Illuminate\Contracts\Support\Arrayable;
+use WendellAdriel\ValidatedDTO\Casting\Castable;
+
+class ArrayableObjectCast implements Castable
+{
+    public function cast(string $property, mixed $value): Arrayable
+    {
+        return app(ArrayableObject::class);
+    }
+}

--- a/tests/Datasets/ArrayableObjectDTO.php
+++ b/tests/Datasets/ArrayableObjectDTO.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WendellAdriel\ValidatedDTO\Tests\Datasets;
 
 use Illuminate\Contracts\Support\Arrayable;

--- a/tests/Datasets/ArrayableObjectDTO.php
+++ b/tests/Datasets/ArrayableObjectDTO.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace WendellAdriel\ValidatedDTO\Tests\Datasets;
+
+use Illuminate\Contracts\Support\Arrayable;
+use WendellAdriel\ValidatedDTO\Attributes\Cast;
+use WendellAdriel\ValidatedDTO\Attributes\Rules;
+use WendellAdriel\ValidatedDTO\Concerns\EmptyCasts;
+use WendellAdriel\ValidatedDTO\Concerns\EmptyDefaults;
+use WendellAdriel\ValidatedDTO\Concerns\EmptyRules;
+use WendellAdriel\ValidatedDTO\ValidatedDTO;
+
+class ArrayableObjectDTO extends ValidatedDTO
+{
+    use EmptyCasts, EmptyDefaults, EmptyRules;
+
+    #[Rules(['required'])]
+    #[Cast(type: ArrayableObjectCast::class)]
+    public Arrayable $object;
+}

--- a/tests/Unit/ArrayCastTest.php
+++ b/tests/Unit/ArrayCastTest.php
@@ -6,6 +6,7 @@ use WendellAdriel\ValidatedDTO\Casting\ArrayCast;
 use WendellAdriel\ValidatedDTO\Casting\BooleanCast;
 use WendellAdriel\ValidatedDTO\Casting\DTOCast;
 use WendellAdriel\ValidatedDTO\Casting\IntegerCast;
+use WendellAdriel\ValidatedDTO\Tests\Datasets\ArrayableObjectDTO;
 use WendellAdriel\ValidatedDTO\Tests\Datasets\ValidatedDTOInstance;
 
 it('properly casts from json string to array')
@@ -55,4 +56,16 @@ it('properly casts an DTOCast', function () {
 
     expect($result[0]->toArray())->toEqual($johnDto->toArray())
         ->and($result[1]->toArray())->toEqual($maryDto->toArray());
+});
+
+it('properly casts an Arrayable object to array', function () {
+    $dto = ArrayableObjectDTO::fromArray([
+        'object' => 'arrayable-object-key',
+    ]);
+
+    expect($dto->toArray())->toBe([
+        'object' => [
+            'key' => 'arrayable-object-key',
+        ],
+    ]);
 });


### PR DESCRIPTION
## Problem
We have a custom cast that translates a string to an object, which works fine when we use it like this:

`$dto->object`

But when we need the values in an array, for example for each VueJS component, we lose that value. The `->toArray()` function makes it an empty array because of PHPs array casting of an object. 

## Solution
With this PR we are trying to add support for the Arrayable interface from Laravel. It already works like this, I just can't figure out how to test this change as easily as possible. I would need a custom cast file that returns an object, a custom object file..

And before I add all of this, I wanted to ask for your opinion on this change, and also on the testing approach. Perhaps you have a better idea?