### PR TITLE
Fixing issue 85 - Declaration of WendellAdriel\ValidatedDTO\SimpleDTO…

### DIFF
--- a/src/Concerns/DataTransformer.php
+++ b/src/Concerns/DataTransformer.php
@@ -13,9 +13,9 @@ trait DataTransformer
         return $this->buildDataForExport();
     }
 
-    public function toJson(): string
+    public function toJson($options = 0): string
     {
-        return json_encode($this->buildDataForExport());
+        return json_encode($this->buildDataForExport(), $options);
     }
 
     public function toPrettyJson(): string

--- a/src/Contracts/BaseDTO.php
+++ b/src/Contracts/BaseDTO.php
@@ -26,7 +26,7 @@ interface BaseDTO
 
     public function toArray(): array;
 
-    public function toJson(): string;
+    public function toJson($options = 0): string;
 
     public function toPrettyJson(): string;
 


### PR DESCRIPTION
Fixes this error in case that you use your DTO in context of Laravel using Jsonable interface.

Declaration of WendellAdriel\ValidatedDTO\SimpleDTO::toJson(): string must be compatible with Illuminate\Contracts\Support\Jsonable::toJson($options = 0)