### PR TITLE
Fixes missing JsonSerializable implementation

### DIFF
--- a/src/SimpleDTO.php
+++ b/src/SimpleDTO.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\ValidationException;
+use JsonSerializable;
 use ReflectionClass;
 use ReflectionProperty;
 use UnitEnum;
@@ -29,7 +30,7 @@ use WendellAdriel\ValidatedDTO\Contracts\BaseDTO;
 use WendellAdriel\ValidatedDTO\Exceptions\CastTargetException;
 use WendellAdriel\ValidatedDTO\Exceptions\MissingCastTypeException;
 
-abstract class SimpleDTO implements BaseDTO, CastsAttributes
+abstract class SimpleDTO implements BaseDTO, CastsAttributes, JsonSerializable
 {
     use DataResolver, DataTransformer;
 
@@ -144,6 +145,14 @@ abstract class SimpleDTO implements BaseDTO, CastsAttributes
         }
 
         return '';
+    }
+
+    /*
+     * JsonSerializable
+     */
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
     }
 
     /**


### PR DESCRIPTION
When using a DTO object, for example in a Resource, due to the lack of a JsonSerializable implementation, the 'lazyValidation' internal property is hit in the json
<img width="191" alt="image" src="https://github.com/user-attachments/assets/e3fcbfe6-004f-46cb-ba61-eedeb8aba05d" />
