### PR TITLE
MorphCast for polymorphic Eloquent model casting?

### DIFF
--- a/src/Casting/MorphCast.php
+++ b/src/Casting/MorphCast.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\ValidatedDTO\Casting;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use WendellAdriel\ValidatedDTO\Exceptions\CastException;
+
+class MorphCast
+{
+    /** @var array<string, mixed> */
+    private array $resolvedDto;
+
+    public function __construct()
+    {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2);
+
+        throw_unless(is_array($trace[1]['object']->dtoData ?? null), new CastException(
+            'MorphCast: Calling DTO instance does not have accessible dtoData array.',
+        ));
+
+        $this->resolvedDto = $trace[1]['object']->dtoData;
+    }
+
+    public function cast(string $property, mixed $value): Model
+    {
+        [$morphTypeKey, $morphIdKey] = $this->resolveMorphKeys($property);
+
+        throw_unless(isset($this->resolvedDto[$morphTypeKey]), new CastException("MorphCast: Missing morph type key [{$morphTypeKey}] in DTO data."));
+
+        $morphClassAlias = $this->resolvedDto[$morphTypeKey];
+
+        $modelClass = Relation::getMorphedModel($morphClassAlias) ?? $morphClassAlias;
+
+        throw_if(! class_exists($modelClass) || ! is_subclass_of($modelClass, Model::class), new CastException("MorphCast: Invalid model class [{$modelClass}]."));
+
+        /** @var Model $modelInstance */
+        $modelInstance = new $modelClass();
+
+        // forceFill is correct here - we're in a DTO casting context with trusted data
+        // and need to preserve all attributes (fillable + non-fillable like id, timestamps)
+        if (is_array($value) && ! empty($value)) {
+            $modelInstance->forceFill($value);
+        }
+
+        return $modelInstance;
+    }
+
+    /**
+     * Resolve morph keys following Laravel convention.
+     * Override this method to customize key resolution.
+     */
+    protected function resolveMorphKeys(string $property): array
+    {
+        return [
+            "{$property}_type", // morph type key
+            "{$property}_id",   // morph id key
+        ];
+    }
+}

--- a/tests/Unit/MorphCastTest.php
+++ b/tests/Unit/MorphCastTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Relations\Relation;
+use WendellAdriel\ValidatedDTO\Casting\MorphCast;
+use WendellAdriel\ValidatedDTO\Exceptions\CastException;
+
+beforeEach(function () {
+    Relation::morphMap([
+        'model_instance' => \WendellAdriel\ValidatedDTO\Tests\Datasets\ModelInstance::class,
+    ]);
+});
+
+it('properly casts to the morphed model class', function () {
+    $dto = new class()
+    {
+        public array $dtoData = [
+            'test_property_type' => 'model_instance',
+        ];
+
+        public function castProperty($value)
+        {
+            $cast = new MorphCast();
+
+            return $cast->cast('test_property', $value);
+        }
+    };
+
+    $model = $dto->castProperty(['name' => 'Jane Doe', 'age' => 25]);
+
+    expect($model)->toBeInstanceOf(\WendellAdriel\ValidatedDTO\Tests\Datasets\ModelInstance::class)
+        ->and($model->toArray())->toBe(['name' => 'Jane Doe', 'age' => 25]);
+});
+
+it('throws exception if morph type key is missing', function () {
+    $dto = new class()
+    {
+        public array $dtoData = [];
+
+        public function castProperty($value)
+        {
+            $cast = new MorphCast();
+
+            return $cast->cast('test_property', $value);
+        }
+    };
+
+    $dto->castProperty(['name' => 'Jane Doe', 'age' => 25]);
+})->throws(CastException::class, 'MorphCast: Missing morph type key [test_property_type] in DTO data.');
+
+it('throws exception if model class is invalid', function () {
+    $dto = new class()
+    {
+        public array $dtoData = [
+            'test_property_type' => 'NonExistentModel',
+        ];
+
+        public function castProperty($value)
+        {
+            $cast = new MorphCast();
+
+            return $cast->cast('test_property', $value);
+        }
+    };
+
+    $dto->castProperty(['name' => 'Jane Doe', 'age' => 25]);
+})->throws(CastException::class, 'MorphCast: Invalid model class [NonExistentModel].');


### PR DESCRIPTION
I’ve implemented a new `MorphCast` class for **ValidatedDTO** that enables casting DTO properties into polymorphic Eloquent models, following Laravel’s conventions (`{property}_type`, `{property}_id`).

## What it does
- Resolves the correct model class via `Relation::morphMap()` or fallback.
- Validates that the resolved class exists and extends `Model`.
- Populates the model instance with trusted DTO data using `forceFill`.
- Provides overridable `resolveMorphKeys()` for custom conventions.

## Test Coverage
- ✅ Properly casts to morphed model class  
- ✅ Throws when morph type key is missing  
- ✅ Throws when model class is invalid  